### PR TITLE
add(frontend#oso): default `oso` ai config to point to prod

### DIFF
--- a/frontend/notebook.html
+++ b/frontend/notebook.html
@@ -71,7 +71,17 @@
         "filename":"notebook.py",
         "mode":"edit",
         "version":"latest",
-        "config":{},
+        "config":{
+          "ai": {
+            "models": {
+              "chat_model": "oso/semantic",
+              "edit_model": "oso/semantic"
+            },
+            "open_ai": {
+              "base_url": "https://agent.opensource.observer/v0"
+            },
+          },
+        },
         "view": {
           // Don't show code in the read mode (it's ugly)
           "showAppCode": false,

--- a/frontend/src/oso-extensions/wasm/controller.tsx
+++ b/frontend/src/oso-extensions/wasm/controller.tsx
@@ -180,6 +180,7 @@ export class DefaultWasmController implements WasmController {
 
     // We minimally need pyoso 0.6.4 for wasm support
     foundPackages.add("pyoso>=0.6.4")
+    foundPackages.add("openai==1.106.1")
 
     if (code.includes("mo.sql")) {
       // We need pandas and duckdb for mo.sql

--- a/packages/wasm-builder/src/server.ts
+++ b/packages/wasm-builder/src/server.ts
@@ -157,6 +157,14 @@ export async function startServer(config: BuildConfig) {
       .send(lockfileJson);
   });
 
+  app.all(/^\/notebook\/api\/.*$/, (req, res) => {
+    const originalUrl = req.url;
+    req.url = req.url.replace('/notebook', '');
+    console.log(`Rewriting API request from ${originalUrl} to ${req.url}`);
+    req.headers.host = `${config.targetHostname}:${config.targetPort}`;
+    proxy.web(req, res, { target: targetService });
+  });
+
   app.all("/{*path}", (req, res) => {
     console.log(`Proxying request to: ${targetService}${req.url}`);
     req.headers.host = `${config.targetHostname}:${config.targetPort}`;


### PR DESCRIPTION
This PR wires up marimo's AI providers to use our OpenAI compatible endpoints. Right now, the `oso/semantic` tag in `chat_model` and `edit_model` is just a placeholder, but I envision this to be something like `oso/semantic-turbo` or `oso/semantic-rich` for different workflow selections.

It also installs `openai`, since it is needed for the AI features in marimo, and it redirects `/notebook/api/` calls to `/api/`, which was causing `404` errors.

<img width="827" height="604" alt="image" src="https://github.com/user-attachments/assets/56500ae1-79f7-48e8-8b4b-efb11f8df052" />

<img width="799" height="893" alt="image" src="https://github.com/user-attachments/assets/f9ac95d9-aa3f-4e9e-b58a-e9c116450b7c" />