### PR TITLE
feat(wasm-builder#oso): create marimo `session` ids on the fly

### DIFF
--- a/packages/wasm-builder/package.json
+++ b/packages/wasm-builder/package.json
@@ -22,6 +22,10 @@
     "pyodide": "0.27.7",
     "smol-toml": "^1.4.2",
     "typescript": "^5.9.2",
+    "ws": "^8.18.3",
     "yargs": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.18.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,9 +732,16 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      ws:
+        specifier: ^8.18.3
+        version: 8.18.3
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
 
 packages:
 


### PR DESCRIPTION
This PR closes opensource-observer/oso#4986 by registering `sessionId`s on the fly for `/api/*` endpoints if they are not registered already in the marimo backend.