### PR TITLE
fix(marimo#oso): redirect `api` calls to `vercel` backend

### DIFF
--- a/marimo/_cli/export/cloudflare.py
+++ b/marimo/_cli/export/cloudflare.py
@@ -32,6 +32,17 @@ export default {
       });
     }
 
+    const apiPrefix = "/notebook/api/";
+    if (url.pathname.startsWith(apiPrefix)) {
+      const remainder = url.pathname.slice(apiPrefix.length);
+      const target = new URL(
+        `https://www.opensource.observer/api/v1/marimo/${remainder}`
+      );
+
+      target.search = url.search;
+      return Response.redirect(target.toString(), 302);
+    }
+
     return env.ASSETS.fetch(request);
   },
 };""".strip()


### PR DESCRIPTION
This PR adds some logic in the cloduflare entry point to redirect `/notebook/aì/...path` routes to `https://www.opensource.observer/api/v1/marimo/...path`. We'll need to implement our logic and keep the same interface to enable API functionality because this is not exposed in the self-contained WASM build. Part of opensource-observer/oso#4987