### PR TITLE
chore(frontend#oso): expose `osoApiKey` in body

### DIFF
--- a/frontend/src/core/codemirror/ai/request.ts
+++ b/frontend/src/core/codemirror/ai/request.ts
@@ -2,7 +2,8 @@
 
 import { waitForConnectionOpen } from "@/core/network/connection";
 import type { AiCompletionRequest } from "@/core/network/types";
-import { getRuntimeManager } from "@/core/runtime/config";
+import { getRuntimeManager, runtimeConfigAtom } from "@/core/runtime/config";
+import { store } from "@/core/state/jotai";
 import type { LanguageAdapterType } from "../language/types";
 
 /**
@@ -30,6 +31,8 @@ ${opts.codeAfter}
 
   await waitForConnectionOpen();
 
+  const authToken = store.get(runtimeConfigAtom).authToken;
+  
   const response = await fetch(
     runtimeManager.getAiURL("completion").toString(),
     {
@@ -41,7 +44,8 @@ ${opts.codeAfter}
         selectedText: opts.selection,
         includeOtherCode: "",
         language: opts.language,
-      } satisfies AiCompletionRequest),
+        ...(authToken && { osoApiKey: authToken }),
+      } satisfies AiCompletionRequest & { osoApiKey?: string }),
     },
   );
 


### PR DESCRIPTION
When using `marimo` on OSO with Cloudflare redirect from `marimo.opensource.observer` to `opensource.observer/api/v1/`, the `Authorization` header gets stripped during the `307` redirect due to browser security policies for `cross-origin` redirects. I added a fallback to include the OSO API key in the request body for the `/api/ai/completion` endpoint. The auth token is retrieved from the runtime config store and included as `osoApiKey` in the body.