### PR TITLE
chore(frontend#oso): hide `FilenameForm` in favor of oso-native one

### DIFF
--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -156,11 +156,11 @@ export const EditApp: React.FC<AppProps> = ({
             "sticky left-0",
           )}
         >
-          {isEditing && (
+          {/* {isEditing && (
             <div className="flex items-center justify-center container">
               <FilenameForm filename={filename} />
             </div>
-          )}
+          )} */}
         </AppHeader>
 
         {/* Don't render until we have a single cell */}

--- a/frontend/src/oso-extensions/oso-notebook-app.tsx
+++ b/frontend/src/oso-extensions/oso-notebook-app.tsx
@@ -156,11 +156,11 @@ export const OSONotebookApp: React.FC<AppProps> = ({
             "sticky left-0",
           )}
         >
-          {isEditing && (
+          {/* {isEditing && (
             <div className="flex items-center justify-center container">
               <FilenameForm filename={filename} />
             </div>
-          )}
+          )} */}
         </AppHeader>
 
         {/* Don't render until we have a single cell */}


### PR DESCRIPTION
This is the new experience:

<img width="1840" height="1110" alt="image" src="https://github.com/user-attachments/assets/2e836dc4-ae78-4486-b3c2-b6db89c03908" />
