### PR TITLE
feat(frontend#oso): save notebook image `previews` via `rpc`

### DIFF
--- a/frontend/src/core/wasm/store.ts
+++ b/frontend/src/core/wasm/store.ts
@@ -93,6 +93,11 @@ export class CompositeFileStore implements FileStore {
     this.stores.splice(index, 0, store);
   }
 
+  getStore<T extends FileStore>(ctor: new (...args: any[]) => T): T | null {
+    const store = this.stores.find((store) => store instanceof ctor) as T;
+    return store ?? null;
+  }
+
   async saveFile(contents: string) {
     await Promise.all(this.stores.map((store) => store.saveFile(contents)));
   }

--- a/frontend/src/oso-extensions/notebook-controls.ts
+++ b/frontend/src/oso-extensions/notebook-controls.ts
@@ -5,12 +5,16 @@ export interface NotebookHostControls {
   saveNotebook: (contents: string) => Promise<void>;
   // Read the contents of a notebook via the host
   readNotebook: () => Promise<string | null>;
+  // Save a preview image of the notebook when it changes
+  saveNotebookPreview: (base64Image: string) => Promise<void>;
 }
 
 export interface NotebookControls {
   createCell: (code: string) => Promise<void>;
 
   triggerAlert: (message: string) => Promise<void>;
+
+  captureNotebookPreview: () => Promise<string | null>;
 }
 
 export type NotebookControlsStub = RpcStub<NotebookControls>;

--- a/frontend/src/oso-extensions/notebook-rpc.tsx
+++ b/frontend/src/oso-extensions/notebook-rpc.tsx
@@ -5,6 +5,7 @@ import type { InitializationCommand, NotebookControls, NotebookControlsHandler, 
 export interface NotebookFileStoreControls {
   saveNotebook: (contents: string) => Promise<void>;
   readNotebook: () => Promise<string | null>;
+  saveNotebookPreview: (base64Image: string) => Promise<void>;
 };
 
 export interface NotebookRpcServer extends NotebookControls {
@@ -18,7 +19,7 @@ export interface NotebookRpcServer extends NotebookControls {
 
 export class NotebookRpc extends RpcTarget implements NotebookRpcServer {
   private allowedDomains: string[];
-  private handlers: Record<NotebookControlsKey, NotebookControlsHandler<NotebookControlsKey>>;
+  private handlers: { [K in NotebookControlsKey]?: NotebookControlsHandler<K> };
   private hostControls: NotebookHostControlsStub | undefined;
   private connections: Record<string, MessageChannel>;
   private handleRequestConnectionBound: (event: MessageEvent<any>) => void;
@@ -28,7 +29,7 @@ export class NotebookRpc extends RpcTarget implements NotebookRpcServer {
   constructor(allowedDomains: string[]) {
     super();
     this.allowedDomains = allowedDomains;
-    this.handlers = {} as Record<NotebookControlsKey, NotebookControlsHandler<NotebookControlsKey>>;
+    this.handlers = {};
     this.connections = {};
     this.handleRequestConnectionBound = this.handleRequestConnection.bind(this);
 
@@ -113,20 +114,27 @@ export class NotebookRpc extends RpcTarget implements NotebookRpcServer {
 
   // We allow late registration of handlers so we can use different handlers
   // in the notebook application
-  async createCell(code: string): Promise<void> {
-    if(!this.handlers.createCell) {
-      console.warn("No handler registered for createCell");
-      throw new Error("No handler registered for createCell");
+  private getHandler<K extends NotebookControlsKey>(key: K): NotebookControlsHandler<K> {
+    const handler = this.handlers[key];
+    if (!handler) {
+      throw new Error(`No handler registered for ${key}`);
     }
-    this.handlers.createCell(code);
+    return handler;
+  }
+
+  async createCell(code: string): Promise<void> {
+    const handler = this.getHandler("createCell");
+    handler(code);
   }
 
   async triggerAlert(message: string): Promise<void> {
-    if(!this.handlers.triggerAlert) {
-      console.warn("No handler registered for triggerAlert");
-      throw new Error("No handler registered for triggerAlert");
-    }
-    this.handlers.triggerAlert(message);
+    const handler = this.getHandler("triggerAlert");
+    handler(message);
+  }
+
+  async captureNotebookPreview(): Promise<string | null> {
+    const handler = this.getHandler("captureNotebookPreview");
+    return handler();
   }
 
   registerHandler<K extends NotebookControlsKey>(key: K, handler: NotebookControlsHandler<K>) {
@@ -147,6 +155,10 @@ export class DummyNotebookRpc implements NotebookRpcServer {
   }
   async triggerAlert(message: string): Promise<void> {
     alert(`DummyNotebookRpc: ${message}`);
+  }
+  async captureNotebookPreview(): Promise<string | null> {
+    console.warn("DummyNotebookRpc: captureNotebookPreview called");
+    return null;
   }
   listen(): void {
     console.warn("DummyNotebookRpc: listen called");
@@ -171,6 +183,9 @@ export class DummyNotebookRpc implements NotebookRpcServer {
       readNotebook: async () => {
         console.warn("DummyNotebookRpc: readNotebook called");
         return null;
+      },
+      saveNotebookPreview: async (_base64Image: string) => {
+        console.warn("DummyNotebookRpc: saveNotebookPreview called");
       }
     }
   }

--- a/frontend/src/oso-extensions/post-message-filestore.ts
+++ b/frontend/src/oso-extensions/post-message-filestore.ts
@@ -1,16 +1,34 @@
 import type { FileStore } from "@/core/wasm/store";
 import type { NotebookRpcServer } from "./notebook-rpc";
 
+type CapturePreview = () => Promise<string | null>;
 
 export class PostMessageFileStore implements FileStore {
   private notebookRpc: NotebookRpcServer;
+  private capturePreview: CapturePreview | null = null;
 
-  constructor(notebookRpc: NotebookRpcServer) {
+  constructor(notebookRpc: NotebookRpcServer, capturePreview?: CapturePreview) {
     this.notebookRpc = notebookRpc;
+    this.capturePreview = capturePreview ?? null;
+  }
+
+  setCapturePreview(capturePreview: CapturePreview | null): void {
+    this.capturePreview = capturePreview;
   }
 
   async saveFile(contents: string): Promise<void> {
-    return this.notebookRpc.getFilestore().saveNotebook(contents);
+    await this.notebookRpc.getFilestore().saveNotebook(contents);
+
+    if (this.capturePreview) {
+      try {
+        const preview = await this.capturePreview();
+        if (preview) {
+          await this.notebookRpc.getFilestore().saveNotebookPreview(preview);
+        }
+      } catch (error) {
+        console.error("Failed to save preview:", error);
+      }
+    }
   }
 
   async readFile(): Promise<string | null> {

--- a/frontend/src/oso-extensions/use-capture-preview.tsx
+++ b/frontend/src/oso-extensions/use-capture-preview.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useRef } from "react";
+import { serializeBlob } from "@/utils/blob";
+
+type Base64ImageString = string & { readonly __base64: unique symbol };
+
+function createBase64String(value: string): Base64ImageString {
+  return value as Base64ImageString;
+}
+
+async function hashBase64(data: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const dataBuffer = encoder.encode(data);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+  const hashArray = [...new Uint8Array(hashBuffer)];
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function fetchImageAsBase64(url: string): Promise<string> {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const dataUrl = await serializeBlob(blob);
+  const base64 = dataUrl.split(",")[1];
+  return base64 ?? "";
+}
+
+function querySelectorAllDeep(selector: string): Element[] {
+  const results: Element[] = [];
+  const visited = new Set<Node>();
+
+  function search(node: Node): void {
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const el = node as Element;
+
+    try {
+      if (el.matches(selector)) {
+        results.push(el);
+      }
+    } catch {
+      // Ignore invalid selectors
+    }
+
+    for (const child of el.children) {
+      search(child);
+    }
+
+    if (el.shadowRoot?.children) {
+      for (const child of el.shadowRoot.children) {
+        search(child);
+      }
+    }
+  }
+
+  search(document.documentElement);
+  return results;
+}
+
+interface Candidate {
+  selector: string;
+  element: HTMLImageElement | HTMLCanvasElement | SVGElement;
+  rect: DOMRect;
+  isHidden: boolean;
+}
+
+function isInViewport(rect: DOMRect): boolean {
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    rect.top < window.innerHeight &&
+    rect.left < window.innerWidth &&
+    rect.bottom > 0 &&
+    rect.right > 0
+  );
+}
+
+export function useCaptureNotebookPreview() {
+  const lastHashRef = useRef<string | null>(null);
+
+  const capturePreviewInternal =
+    useCallback(async (): Promise<Base64ImageString | null> => {
+      const selectors = [
+        // TODO(jabolo): Add more selectors as needed for major plotting libraries
+        "svg.main-svg", // plotly
+        'img[src^="data:image"]',
+        'img[src^="blob:"]',
+        "img",
+        "canvas",
+      ];
+
+      const candidates: Candidate[] = [];
+
+      for (const selector of selectors) {
+        const elements = querySelectorAllDeep(selector);
+        for (const element of elements) {
+          if (
+            !(
+              element instanceof HTMLImageElement ||
+              element instanceof HTMLCanvasElement ||
+              element instanceof SVGElement
+            )
+          ) {
+            continue;
+          }
+
+          const computedStyle = window.getComputedStyle(element);
+          const isHidden =
+            computedStyle.display === "none" ||
+            computedStyle.visibility === "hidden";
+
+          candidates.push({
+            selector,
+            element,
+            rect: element.getBoundingClientRect(),
+            isHidden,
+          });
+        }
+      }
+
+      const visibleCandidate = candidates.find(
+        (c) => !c.isHidden && isInViewport(c.rect),
+      );
+      if (!visibleCandidate) return null;
+
+      const { element: targetElement } = visibleCandidate;
+
+      if (targetElement instanceof HTMLImageElement) {
+        return captureImageElement(targetElement);
+      }
+      if (targetElement instanceof HTMLCanvasElement) {
+        return captureCanvasElement(targetElement);
+      }
+      if (targetElement instanceof SVGElement) {
+        return captureSvgElement(targetElement);
+      }
+
+      return null;
+    }, []);
+
+  return useCallback(async (): Promise<Base64ImageString | null> => {
+    const preview = await capturePreviewInternal();
+    if (!preview) return null;
+
+    const hash = await hashBase64(preview);
+    if (hash === lastHashRef.current) return null;
+
+    lastHashRef.current = hash;
+    return preview;
+  }, [capturePreviewInternal]);
+}
+
+async function captureImageElement(
+  img: HTMLImageElement,
+): Promise<Base64ImageString | null> {
+  const src = img.src;
+
+  if (src.startsWith("data:")) {
+    return createBase64String(src);
+  }
+
+  try {
+    const base64 = await fetchImageAsBase64(src);
+    return createBase64String(`data:image/png;base64,${base64}`);
+  } catch {
+    return null;
+  }
+}
+
+async function captureCanvasElement(
+  canvas: HTMLCanvasElement,
+): Promise<Base64ImageString> {
+  const dataUrl = canvas.toDataURL("image/png");
+  return createBase64String(dataUrl);
+}
+
+async function captureSvgElement(
+  svg: SVGElement,
+): Promise<Base64ImageString | null> {
+  try {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    const rect = svg.getBoundingClientRect();
+    canvas.width = Math.ceil(rect.width);
+    canvas.height = Math.ceil(rect.height);
+
+    const svgString = new XMLSerializer().serializeToString(svg);
+    const url = URL.createObjectURL(
+      new Blob([svgString], { type: "image/svg+xml" }),
+    );
+
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = reject;
+      img.src = url;
+    });
+
+    ctx.drawImage(img, 0, 0);
+    URL.revokeObjectURL(url);
+
+    const dataUrl = canvas.toDataURL("image/png");
+    return createBase64String(dataUrl);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/oso-extensions/wrapper.tsx
+++ b/frontend/src/oso-extensions/wrapper.tsx
@@ -10,6 +10,9 @@ import { setLatestEngineSelected, useDataSourceActions } from "@/core/datasets/d
 import type { ConnectionName } from "@/core/datasets/engines";
 import type { AddCellWithAIHook } from "@/components/editor/ai/add-cell-with-ai";
 import { useNotebookRpcServer } from "./notebook-rpc";
+import { useCaptureNotebookPreview } from "@/oso-extensions/use-capture-preview";
+import { notebookFileStore } from "@/core/wasm/store";
+import { PostMessageFileStore } from "@/oso-extensions/post-message-filestore";
 
 declare global {
   interface WindowEventMap {
@@ -29,6 +32,7 @@ export const OSOWrapper: React.FC<PropsWithChildren> = ({ children }) => {
   const actions = useCellActions();
   const dataSourceActions = useDataSourceActions();
   const notebookRpcServer = useNotebookRpcServer();
+  const capturePreview = useCaptureNotebookPreview();
 
   const createCellAtEnd = useCallback(async (code: string) => {
     actions.createNewCell({
@@ -36,9 +40,21 @@ export const OSOWrapper: React.FC<PropsWithChildren> = ({ children }) => {
       code: code,
       before: false,
     });
-  }, []);
+  }, [actions]);
+
+  useEffect(() => {
+    const filestore = notebookFileStore.getStore(PostMessageFileStore);
+    if (!filestore) {
+      return;
+    }
+    filestore.setCapturePreview(capturePreview);
+    return () => {
+      filestore.setCapturePreview(null);
+    };
+  }, [capturePreview]);
 
   notebookRpcServer.registerHandler("createCell", createCellAtEnd);
+  notebookRpcServer.registerHandler("captureNotebookPreview", capturePreview);
 
   const addCellWithAICallback = useCallback((ev: CustomEvent<AddCellWithAIHook>) => {
     const { setInput } = ev.detail;


### PR DESCRIPTION
This PR is part of opensource-observer/oso#5031. It implements all the logic to find the first image in the user's notebook, convert it to a data URL (base64 `png`), and send via `rpc` to the parent frame, which is responsible of saving to `r2`.
