### PR TITLE
fix(oso-extensions#oso): notebook image `preview` save

### DIFF
--- a/frontend/src/oso-extensions/post-message-filestore.ts
+++ b/frontend/src/oso-extensions/post-message-filestore.ts
@@ -2,18 +2,20 @@ import type { FileStore } from "@/core/wasm/store";
 import type { NotebookRpcServer } from "./notebook-rpc";
 
 type CapturePreview = () => Promise<string | null>;
+type ConfirmSave = () => void;
 
 export class PostMessageFileStore implements FileStore {
   private notebookRpc: NotebookRpcServer;
   private capturePreview: CapturePreview | null = null;
+  private confirmSave: ConfirmSave | null = null;
 
-  constructor(notebookRpc: NotebookRpcServer, capturePreview?: CapturePreview) {
+  constructor(notebookRpc: NotebookRpcServer) {
     this.notebookRpc = notebookRpc;
-    this.capturePreview = capturePreview ?? null;
   }
 
-  setCapturePreview(capturePreview: CapturePreview | null): void {
+  setCapturePreview(capturePreview: CapturePreview | null, confirmSave?: ConfirmSave | null): void {
     this.capturePreview = capturePreview;
+    this.confirmSave = confirmSave ?? null;
   }
 
   async saveFile(contents: string): Promise<void> {
@@ -24,6 +26,7 @@ export class PostMessageFileStore implements FileStore {
         const preview = await this.capturePreview();
         if (preview) {
           await this.notebookRpc.getFilestore().saveNotebookPreview(preview);
+          this.confirmSave?.();
         }
       } catch (error) {
         console.error("Failed to save preview:", error);

--- a/frontend/src/oso-extensions/use-capture-preview.tsx
+++ b/frontend/src/oso-extensions/use-capture-preview.tsx
@@ -65,19 +65,12 @@ interface Candidate {
   isHidden: boolean;
 }
 
-function isInViewport(rect: DOMRect): boolean {
-  return (
-    rect.width > 0 &&
-    rect.height > 0 &&
-    rect.top < window.innerHeight &&
-    rect.left < window.innerWidth &&
-    rect.bottom > 0 &&
-    rect.right > 0
-  );
-}
-
-export function useCaptureNotebookPreview() {
+export function useCaptureNotebookPreview(): {
+  capture: () => Promise<Base64ImageString | null>;
+  confirmSave: () => void;
+} {
   const lastHashRef = useRef<string | null>(null);
+  const pendingHashRef = useRef<string | null>(null);
 
   const capturePreviewInternal =
     useCallback(async (): Promise<Base64ImageString | null> => {
@@ -120,7 +113,7 @@ export function useCaptureNotebookPreview() {
       }
 
       const visibleCandidate = candidates.find(
-        (c) => !c.isHidden && isInViewport(c.rect),
+        (c) => !c.isHidden && c.rect.width > 0 && c.rect.height > 0,
       );
       if (!visibleCandidate) return null;
 
@@ -139,16 +132,25 @@ export function useCaptureNotebookPreview() {
       return null;
     }, []);
 
-  return useCallback(async (): Promise<Base64ImageString | null> => {
+  const capture = useCallback(async (): Promise<Base64ImageString | null> => {
     const preview = await capturePreviewInternal();
     if (!preview) return null;
 
     const hash = await hashBase64(preview);
     if (hash === lastHashRef.current) return null;
 
-    lastHashRef.current = hash;
+    pendingHashRef.current = hash;
     return preview;
   }, [capturePreviewInternal]);
+
+  const confirmSave = useCallback(() => {
+    if (pendingHashRef.current) {
+      lastHashRef.current = pendingHashRef.current;
+      pendingHashRef.current = null;
+    }
+  }, []);
+
+  return { capture, confirmSave };
 }
 
 async function captureImageElement(

--- a/frontend/src/oso-extensions/wrapper.tsx
+++ b/frontend/src/oso-extensions/wrapper.tsx
@@ -32,7 +32,7 @@ export const OSOWrapper: React.FC<PropsWithChildren> = ({ children }) => {
   const actions = useCellActions();
   const dataSourceActions = useDataSourceActions();
   const notebookRpcServer = useNotebookRpcServer();
-  const capturePreview = useCaptureNotebookPreview();
+  const { capture: capturePreview, confirmSave: confirmPreviewSave } = useCaptureNotebookPreview();
 
   const createCellAtEnd = useCallback(async (code: string) => {
     actions.createNewCell({
@@ -47,11 +47,11 @@ export const OSOWrapper: React.FC<PropsWithChildren> = ({ children }) => {
     if (!filestore) {
       return;
     }
-    filestore.setCapturePreview(capturePreview);
+    filestore.setCapturePreview(capturePreview, confirmPreviewSave);
     return () => {
-      filestore.setCapturePreview(null);
+      filestore.setCapturePreview(null, null);
     };
-  }, [capturePreview]);
+  }, [capturePreview, confirmPreviewSave]);
 
   notebookRpcServer.registerHandler("createCell", createCellAtEnd);
   notebookRpcServer.registerHandler("captureNotebookPreview", capturePreview);


### PR DESCRIPTION
This PR closes OSO-2382. The issue was that we only saved images if they were within the viewport (so out of screen images wouldn't save) combined with aggressive caching (so the image got cached when it was out of screen, triggering no new image preview saves).