### PR TITLE
fix(frontend#oso): handle `data:` urls in anywidget js imports

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -68,6 +68,12 @@ const AnyWidgetSlot = (props: Props) => {
     refetch,
   } = useAsyncData(async () => {
     const url = asRemoteURL(jsUrl).toString();
+    if (url.startsWith("data:")) {
+      const base64 = url.split(",")[1];
+      const js = atob(base64);
+      const blob = new Blob([js], { type: "text/javascript" });
+      return await import(/* @vite-ignore */ URL.createObjectURL(blob));
+    }
     return await import(/* @vite-ignore */ url);
     // Re-render on jsHash change (which is a hash of the contents of the file)
     // instead of a jsUrl change because URLs may change without the contents


### PR DESCRIPTION
This PR closes OSO-2458. Importing from a `base64` data string is not allowed, so this PR creates a `blob` from it and imports that instead, which is allowed. We don't need to do all the python post-processing that's hard to maintain!