### PR TITLE
fix(frontend#oso): revert: handle `data:` urls in anywidget js imports

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -68,12 +68,6 @@ const AnyWidgetSlot = (props: Props) => {
     refetch,
   } = useAsyncData(async () => {
     const url = asRemoteURL(jsUrl).toString();
-    if (url.startsWith("data:")) {
-      const base64 = url.split(",")[1];
-      const js = atob(base64);
-      const blob = new Blob([js], { type: "text/javascript" });
-      return await import(/* @vite-ignore */ URL.createObjectURL(blob));
-    }
     return await import(/* @vite-ignore */ url);
     // Re-render on jsHash change (which is a hash of the contents of the file)
     // instead of a jsUrl change because URLs may change without the contents


### PR DESCRIPTION
This reverts commit 34dfb5c8b1efca627b5a0d7a0a9d9eb90fa18759. This solution does not work and we should not follow this approach, it's a bandaid.
