### PR TITLE
fix(oso): allow subdomains in notebook RPC origin check

### DIFF
--- a/frontend/src/oso-extensions/notebook-rpc.tsx
+++ b/frontend/src/oso-extensions/notebook-rpc.tsx
@@ -108,8 +108,23 @@ export class NotebookRpc extends RpcTarget implements NotebookRpcServer {
     if (origin.includes("localhost") || origin.includes("127.0.0.1")) {
       return true;
     }
-    const domain = new URL(origin).hostname;
-    return this.allowedDomains.includes(domain);
+    let domain: string;
+    try {
+      domain = new URL(origin).hostname;
+    } catch {
+      return false;
+    }
+    // Allow an exact match or any subdomain of an allowed domain. Listing a
+    // base domain (e.g. "oso.xyz") therefore also permits "www.oso.xyz" and
+    // per-branch preview hosts such as "<branch>.preview.oso.xyz", which are
+    // dynamic and cannot be enumerated in the allow-list. Without subdomain
+    // matching, the host <-> notebook postMessage handshake is rejected on
+    // preview deployments, so the notebook never receives its host-driven
+    // initialization (including the full-width app-config overload) and
+    // renders at its narrow authored width.
+    return this.allowedDomains.some(
+      (allowed) => domain === allowed || domain.endsWith(`.${allowed}`),
+    );
   }
 
   // We allow late registration of handlers so we can use different handlers


### PR DESCRIPTION
## 📝 Summary

Published notebooks render at a too-narrow width on Vercel **preview** deployments (`*.preview.oso.xyz`) while rendering correctly on production (`www.oso.xyz`). The cause is the notebook RPC origin allow-list rejecting preview subdomains.

## 🔍 Description of Changes

`NotebookRpc.isOriginAllowedDomain` (`frontend/src/oso-extensions/notebook-rpc.tsx`) validated the parent-window origin with an **exact hostname match** against `VITE_ALLOWED_DOMAINS`:

```js
const domain = new URL(origin).hostname;
return this.allowedDomains.includes(domain);
```

Production (`www.oso.xyz`) matches, but per-branch preview deployments use dynamic subdomains like `<branch>.preview.oso.xyz` that can never match exactly. On previews, the host→notebook `requestConnection` handshake is therefore rejected (`console.warn("Ignoring message from invalid origin: …")`), so:

1. the RPC connection never establishes,
2. `initStore`'s `await notebookRpc.waitForFsReady()` (`oso-mount.tsx`) times out,
3. the notebook never receives its host-driven initialization — including the full-width app-config overload (`_MARIMO_APP_OVERLOAD_WIDTH="full"` → `overloads_from_env()`),

and it falls back to its narrow authored width.

**Change:** match an allowed domain **exactly _or_ as a subdomain**, and guard URL parsing so a malformed origin returns `false` instead of throwing out of the message handler:

```js
return this.allowedDomains.some(
  (allowed) => domain === allowed || domain.endsWith(`.${allowed}`),
);
```

Listing a base domain (e.g. `oso.xyz`) then permits `www.oso.xyz` and every `<branch>.preview.oso.xyz` host.

**Deployment note:** for previews to be covered, `VITE_ALLOWED_DOMAINS` must include a base domain (e.g. `oso.xyz`) that the preview hosts are subdomains of. This widens trust to all `*.oso.xyz` — acceptable here since OSO controls that zone, but a conscious trust-boundary choice.

## 📋 Checklist

- [x] I have read the contributor guidelines.
- [ ] For large changes, or changes that affect the public API: N/A — small change confined to the OSO fork extension (`oso-extensions/notebook-rpc.tsx`).
- [ ] I have added tests for the changes made — there is currently no test module for `notebook-rpc.tsx` and the matching logic lives in a private method; happy to extract it and add a unit test if preferred.
- [ ] I have run the code and verified that it works as expected — the root cause was confirmed by reproduction (byte-identical-to-main preview renders narrow; production renders full-width) and code tracing; I was not able to run the marimo frontend build in this environment, so CI (`lint`/`typecheck`/`test`/`build`) and a preview check should validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkdiq9ETjhi2Uxy93BSYEg)_